### PR TITLE
Import Microsoft.PowerShell.Archive and force Compress-Archive

### DIFF
--- a/package/build_Portable.cmd
+++ b/package/build_Portable.cmd
@@ -30,7 +30,7 @@ echo Zipping app
 echo ################################
 echo.
 
-powershell Compress-Archive -Path "..\src\bin\publish\portable\*" -DestinationPath "Output\DLSS` Swapper-%app_version%-portable.zip" || goto :error
+powershell Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process; Import-Module Microsoft.PowerShell.Archive; Compress-Archive -Force -Path "..\src\bin\publish\portable\*" -DestinationPath "Output\DLSS` Swapper-%app_version%-portable.zip" || goto :error
 
 REM Everything is fine, go to the end of the file.
 goto :EOF


### PR DESCRIPTION
Fixes 'CouldNotAutoloadMatchingModule' error on ./package/build_Portable.cmd
<img width="868" alt="image" src="https://user-images.githubusercontent.com/1141771/218504995-2abcb2d9-32af-4137-a391-f2104d19e631.png">
